### PR TITLE
Updated gateway button response

### DIFF
--- a/src/MintButton.tsx
+++ b/src/MintButton.tsx
@@ -46,6 +46,7 @@ export const MintButton = ({
     return (
         <CTAButton
             disabled={
+                clicked ||
                 candyMachine?.state.isSoldOut || isSoldOut ||
                 isMinting ||
                 !isActive ||
@@ -69,7 +70,7 @@ export const MintButton = ({
                 'SOLD OUT'
             ) : isActive ? (
                 isVerifying ? 'VERIFYING...' :
-                    isMinting ? (
+                    isMinting || clicked ? (
                         <CircularProgress/>
                     ) : (
                         "MINT"


### PR DESCRIPTION
# Description
This fixes the civic gateway button from being clickable during token issuance

## Type of change

- [x] Bug fix

## How Has This Been Tested?
Start a CM with gatekeeper set and see that the mint button is not clickable until after the nft is minted
