### PR TITLE
bump @civic/solana-gateway-react to 0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/runtime": "7.x",
-    "@civic/solana-gateway-react": "^0.4.12",
+    "@civic/solana-gateway-react": "^0.7.4",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",


### PR DESCRIPTION
- Bump @civic/solana-gateway-react to 0.7.4
- Removes unnecessary @type dependencies causing integration problems.